### PR TITLE
Postpone window initialization

### DIFF
--- a/KeePass/Program.cs
+++ b/KeePass/Program.cs
@@ -249,11 +249,6 @@ namespace KeePass
 			if(!string.IsNullOrEmpty(strWaDisable))
 				MonoWorkarounds.SetEnabled(strWaDisable, false);
 
-			DpiUtil.ConfigureProcess();
-			Application.EnableVisualStyles();
-			Application.SetCompatibleTextRenderingDefault(false);
-			Application.DoEvents(); // Required
-
 #if DEBUG
 			string strInitialWorkDir = WinUtil.GetWorkingDirectory();
 #endif
@@ -410,6 +405,11 @@ namespace KeePass
 			//	return;
 			// }
 			// #endif
+
+			DpiUtil.ConfigureProcess();
+			Application.EnableVisualStyles();
+			Application.SetCompatibleTextRenderingDefault(false);
+			Application.DoEvents(); // Required
 
 			try { m_nAppMessage = NativeMethods.RegisterWindowMessage(m_strWndMsgID); }
 			catch(Exception) { Debug.Assert(NativeLib.IsUnix()); }


### PR DESCRIPTION
 This allows `.plgx` generation without X server. This is needed in order to automatically generate a `.plgx` for my plugin on my build server which does not have X installed.