### PR TITLE
Lock workspace even on data loss option

### DIFF
--- a/KeePass/App/Configuration/AceSecurity.cs
+++ b/KeePass/App/Configuration/AceSecurity.cs
@@ -219,6 +219,14 @@ namespace KeePass.App.Configuration
 			get { return m_bAlwaysExitInsteadOfLocking; }
 			set { m_bAlwaysExitInsteadOfLocking = value; }
 		}
+
+        private bool m_bLockEvenOnDataLoss = false;
+        [DefaultValue(false)]
+        public bool LockEvenOnDataLoss
+        {
+            get { return m_bLockEvenOnDataLoss; }
+            set { m_bLockEvenOnDataLoss = value; }
+        }
 	}
 
 	public sealed class AceMasterPassword

--- a/KeePass/Forms/OptionsForm.cs
+++ b/KeePass/Forms/OptionsForm.cs
@@ -310,6 +310,8 @@ namespace KeePass.Forms
 				lvg, KPRes.LockOnSessionSwitch + strSEvSuffix, obNoSEv);
 			m_cdxSecurityOptions.CreateItem(aceWL, "LockOnSuspend",
 				lvg, KPRes.LockOnSuspend + strSEvSuffix, obNoSEv);
+            m_cdxSecurityOptions.CreateItem(aceWL, "LockEvenOnDataLoss",
+                lvg, KPRes.LockEvenOnDataLoss + strSEvSuffix, obNoSEv);
 			m_cdxSecurityOptions.CreateItem(aceWL, "LockOnRemoteControlChange",
 				lvg, KPRes.LockOnRemoteControlChange + strSEvSuffix, obNoSEv);
 			m_cdxSecurityOptions.CreateItem(aceWL, "ExitInsteadOfLockingAfterTime",

--- a/KeePass/Resources/KPRes.Generated.cs
+++ b/KeePass/Resources/KPRes.Generated.cs
@@ -475,6 +475,7 @@ namespace KeePass.Resources
 			m_strLockOnRemoteControlChange = TryGetEx(dictNew, "LockOnRemoteControlChange", m_strLockOnRemoteControlChange);
 			m_strLockOnSessionSwitch = TryGetEx(dictNew, "LockOnSessionSwitch", m_strLockOnSessionSwitch);
 			m_strLockOnSuspend = TryGetEx(dictNew, "LockOnSuspend", m_strLockOnSuspend);
+            m_strLockEvenOnDataLoss = TryGetEx(dictNew, "LockEvenOnDataLoss", m_strLockEvenOnDataLoss);
 			m_strMainInstruction = TryGetEx(dictNew, "MainInstruction", m_strMainInstruction);
 			m_strMainWindow = TryGetEx(dictNew, "MainWindow", m_strMainWindow);
 			m_strMasterKey = TryGetEx(dictNew, "MasterKey", m_strMasterKey);
@@ -6611,7 +6612,18 @@ namespace KeePass.Resources
 			get { return m_strLockOnSuspend; }
 		}
 
-		private static string m_strMainInstruction =
+        private static string m_strLockEvenOnDataLoss =
+            @"Lock workspace even if data will be lost after it";
+        /// <summary>
+        /// Look up a localized string similar to
+        /// 'Lock workspace even if data will be lost after it'.
+        /// </summary>
+        public static string LockEvenOnDataLoss
+        {
+            get { return m_strLockEvenOnDataLoss; }
+        }
+
+        private static string m_strMainInstruction =
 			@"Main instruction";
 		/// <summary>
 		/// Look up a localized string similar to

--- a/KeePass/UI/GlobalWindowManager.cs
+++ b/KeePass/UI/GlobalWindowManager.cs
@@ -83,6 +83,7 @@ namespace KeePass.UI
 				{
 					if(g_vDialogs.Count > 0) return false;
 					if(MessageService.CurrentMessageCount > 0) return false;
+                    if (Program.Config.Security.WorkspaceLocking.LockEvenOnDataLoss) return true;
 
 					foreach(KeyValuePair<Form, IGwmWindow> kvp in g_vWindows)
 					{
@@ -214,8 +215,12 @@ namespace KeePass.UI
 
 			foreach(KeyValuePair<Form, IGwmWindow> kvp in vWindows)
 			{
-				if(kvp.Value == null) continue;
-				else if(kvp.Value.CanCloseWithoutDataLoss)
+                bool ignoreDataLoss = Program.Config.Security.WorkspaceLocking.LockEvenOnDataLoss;
+                if(!ignoreDataLoss)
+                {
+                    if (kvp.Value == null || !kvp.Value.CanCloseWithoutDataLoss) continue;
+                }
+                else
 				{
 					if(kvp.Key.InvokeRequired)
 						kvp.Key.Invoke(new CloseFormDelegate(
@@ -224,7 +229,8 @@ namespace KeePass.UI
 
 					Application.DoEvents();
 				}
-			}
+                
+            }
 		}
 
 		private delegate void CloseFormDelegate(Form f);

--- a/KeePass/Util/XmlSerialization/XmlSerializerEx.Gen.cs
+++ b/KeePass/Util/XmlSerialization/XmlSerializerEx.Gen.cs
@@ -1778,6 +1778,9 @@ namespace KeePass.Util.XmlSerialization
 					case "AlwaysExitInsteadOfLocking":
 						o.AlwaysExitInsteadOfLocking = ReadBoolean(xr);
 						break;
+                    case "LockEvenOnDataLoss":
+                        o.LockEvenOnDataLoss = ReadBoolean(xr);
+                        break;
 					default:
 						Debug.Assert(false);
 						xr.Skip();


### PR DESCRIPTION
Added configuration option to Tools -> Options -> Security so that workspace could be locked (primarily on user switch action on Windows [Win+L]) even if some data might be lost (any windows like 'Edit password' are opened).