### PR TITLE
Added developmentDependency to nuspec

### DIFF
--- a/KeePass/KeePass.nuspec
+++ b/KeePass/KeePass.nuspec
@@ -17,6 +17,7 @@
     <dependencies>
       <group targetFramework=".NETFramework4.6.2" />
     </dependencies>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
     <file src="..\keepass_256x256.png" target="content\" />


### PR DESCRIPTION
Added developmentDependency to nuspec to mark package as development-only-dependency [https://docs.microsoft.com/en-us/nuget/reference/nuspec#developmentdependency](https://docs.microsoft.com/en-us/nuget/reference/nuspec#developmentdependency).