### PR TITLE
fix: Set Prefer Native Arm64 on true.

### DIFF
--- a/KeePass/KeePass.csproj
+++ b/KeePass/KeePass.csproj
@@ -46,6 +46,7 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\Build\KeePass\Debug\KeePass.xml</DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
+    <PreferNativeArm64>true</PreferNativeArm64>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -59,6 +60,7 @@
     </DocumentationFile>
     <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
     <Prefer32Bit>false</Prefer32Bit>
+    <PreferNativeArm64>true</PreferNativeArm64>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/KeePassLib/KeePassLib.csproj
+++ b/KeePassLib/KeePassLib.csproj
@@ -46,6 +46,7 @@
     <DocumentationFile>..\Build\KeePassLib\Debug\KeePassLib.xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
     <Prefer32Bit>false</Prefer32Bit>
+    <PreferNativeArm64>true</PreferNativeArm64>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -57,6 +58,7 @@
     <DocumentationFile>..\Build\KeePassLib\Release\KeePassLib.xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
     <Prefer32Bit>false</Prefer32Bit>
+    <PreferNativeArm64>true</PreferNativeArm64>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Translation/TrlUtil/TrlUtil.csproj
+++ b/Translation/TrlUtil/TrlUtil.csproj
@@ -28,6 +28,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <PreferNativeArm64>true</PreferNativeArm64>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -37,6 +38,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <PreferNativeArm64>true</PreferNativeArm64>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />


### PR DESCRIPTION
This PR will enable Native ARM64 support. By default, building an .NET Application for Any CPU will not run the app in ARM64 modus but still emulated in X64 mode. Enable the PreferNativeArm64 feature will tell the computer to run the application in AMR64 modus.

<img width="683" alt="image" src="https://github.com/user-attachments/assets/dd130681-1752-4f2a-a9f1-8d12a5c2b96f" />

Working sample can be found here: https://github.com/rdeveen/KeePass2.x/releases/tag/2.57.1